### PR TITLE
Fix pkg-config spec after merging 'json' branch

### DIFF
--- a/libsearpc.pc.in
+++ b/libsearpc.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: libsearpc
 Description: Simple C rpc library
 Version: @VERSION@
-Libs: -L${libdir} -lsearpc -lsearpc-json-glib
+Libs: -L${libdir} -lsearpc
 Cflags: -I${includedir} -I${includedir}/searpc
 Requires: gobject-2.0 gio-2.0


### PR DESCRIPTION
libsearpc.pc still contains a reference to the searpc-json-glib library which
is not build anymore. It is safe to remove the reference.
