### PR TITLE
Add missing jansson dependency in pkg-config spec

### DIFF
--- a/libsearpc.pc.in
+++ b/libsearpc.pc.in
@@ -8,4 +8,4 @@ Description: Simple C rpc library
 Version: @VERSION@
 Libs: -L${libdir} -lsearpc
 Cflags: -I${includedir} -I${includedir}/searpc
-Requires: gobject-2.0 gio-2.0
+Requires: gobject-2.0 gio-2.0 jansson


### PR DESCRIPTION
libsearpc has a new dependency on libjansson which is not included in the pkg-config spec file. This means that the jansson library will not be added to the linker commandline for programs using libsearpc (like ccnet). This breaks libtool linking for me, making ccnet impossible to build.
