### PR TITLE
Update libsearpc.pc.in

### DIFF
--- a/libsearpc.pc.in
+++ b/libsearpc.pc.in
@@ -1,4 +1,4 @@
-prefix=(DESTDIR)@prefix@
+prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
@@ -8,4 +8,4 @@ Description: Simple C rpc library
 Version: @VERSION@
 Libs: -L${libdir} -lsearpc
 Cflags: -I${includedir} -I${includedir}/searpc
-Requires: gobject-2.0 gio-2.0 jansson
+Requires: gobject-2.0 >= 2.26.0 gio-2.0 >= 2.26.0 jansson >= 2.2.1


### PR DESCRIPTION
DESTDIR shouldn't be used in PKG-CONFIG file. All $(DESTDIR) variables should only be used in Makefile. If users want to install the file into special location, let them choose the prefix before configure.

And if you have dependencies with specific version requirements, it's better to write them in the pc as well.
