### PR TITLE
make code compatible with both python2 and python3

### DIFF
--- a/lib/searpc-codegen.py
+++ b/lib/searpc-codegen.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 """
 Generate function define macros.
@@ -103,7 +108,7 @@ def generate_marshal(ret_type, arg_types):
 def gen_marshal_functions(f):
     from rpc_table import func_table
     for item in func_table:
-        print >>f, generate_marshal(item[0], item[1])
+        print(generate_marshal(item[0], item[1]), file=f)
 
 
 marshal_register_item = r"""
@@ -130,11 +135,11 @@ def generate_marshal_register_item(ret_type, arg_types):
 
 def gen_marshal_register_function(f):
     from rpc_table import func_table
-    print >>f, "static void register_marshals()"""
-    print >>f, "{"
+    print("static void register_marshals()""", file=f)
+    print("{", file=f)
     for item in func_table:
-        print >>f, generate_marshal_register_item(item[0], item[1]),
-    print >>f, "}"
+        print(generate_marshal_register_item(item[0], item[1]), end=' ', file=f)
+    print("}", file=f)
 
 signature_template = r"""
 inline static gchar *
@@ -164,7 +169,7 @@ def generate_signature(ret_type, arg_types):
 def gen_signature_list():
     f = open('searpc-signature.h', 'w')
     for item in func_table:
-        print >>f,generate_signature(item[0], item[1])
+        print(generate_signature(item[0], item[1]), file=f)
     f.close()
 
 
@@ -178,8 +183,8 @@ if __name__ == "__main__":
         f = os.path.basename(abspath)
         mod = f[:f.rfind('.')]
         sys.path.append(d)
-        rpc_mod = __import__(mod, globals(), locals(), [], -1)
-        print "loaded func_table from %s" % (rpc_mod.__file__)
+        rpc_mod = __import__(mod, globals(), locals(), [], 0)
+        print("loaded func_table from %s" % (rpc_mod.__file__))
         func_table = rpc_mod.func_table
     else:
         # load from default rpc_table.py

--- a/pysearpc/server.py
+++ b/pysearpc/server.py
@@ -1,6 +1,6 @@
 import json
 
-from common import SearpcError
+from .common import SearpcError
 
 class SearpcService(object):
     def __init__(self, name):
@@ -25,7 +25,7 @@ class SearpcServer(object):
         """input str -> output str"""
         try:
             argv = json.loads(fcallstr)
-        except Exception, e:
+        except Exception as e:
             raise SearpcError('bad call str: ' + str(e))
 
         service = self.services[svcname]
@@ -41,7 +41,7 @@ class SearpcServer(object):
     def call_function(self, svcname, fcallstr):
         try:
             retVal = self._call_function(svcname, fcallstr)
-        except Exception, e:
+        except Exception as e:
             ret = {'err_code': 555, 'err_msg': str(e)}
         else:
             ret = {'ret': retVal}


### PR DESCRIPTION
These changes allow the python code to run on both python2 and python3.  It was tested under python2.7 and python3.4.  The behavior was the same with both.

The intent is to make this program easier to package on FreeBSD when python3 is the default python version.

Please consider this request for inclusion in your repository.