### PR TITLE
Fixed demo target include paths

### DIFF
--- a/demo/Makefile.am
+++ b/demo/Makefile.am
@@ -1,6 +1,7 @@
 generated_sources = searpc-signature.h searpc-marshal.h
 
 AM_CFLAGS = @GLIB_CFLAGS@ \
+	@JANSSON_CFLAGS@ \
 	-I${top_srcdir}/lib
 
 # we need to generate the first


### PR DESCRIPTION
Before, the demo target wouldn't compile, if Jansson's header files aren't in some standard include directory.

With this change the proper parameters are passed to the compiler, allowing compiling and installing without workarounds.