### PR TITLE
Check jansson parsing function return codes for requests

### DIFF
--- a/lib/searpc-server.c
+++ b/lib/searpc-server.c
@@ -279,7 +279,20 @@ searpc_server_call_function (const char *svc_name,
         return error_to_json (511, buf, ret_len);
     }
 
-    const char *fname = json_string_value (json_array_get(array, 0));
+    const json_t *request_array = json_array_get(array, 0);
+    if (!request_array) {
+        char buf[256];
+        snprintf (buf, 255, "request array is empty");
+        json_decref (array);
+        return error_to_json (500, buf, ret_len);
+    }
+    const char *fname = json_string_value (request_array);
+    if (!fname) {
+        char buf[256];
+        snprintf (buf, 255, "first request parameter is not a string");
+        json_decref (array);
+        return error_to_json (500, buf, ret_len);
+    }
     FuncItem *fitem = g_hash_table_lookup(service->func_table, fname);
     if (!fitem) {
         char buf[256];


### PR DESCRIPTION
The code for dispatching a request json to registered functions so far did not correctly check the return codes of jannson json parsing functions which allowed segmentation faults for specially crafted
inputs. This PR adds the required error handling. I have found this through fuzzing the code.

I am not sure, but potentially someone could use this to craft some attacks.

Btw, why are there no issues allowed in this repo?