### PR TITLE
fix multiple double-frees in async client

### DIFF
--- a/demo/demo-async-client.c
+++ b/demo/demo-async-client.c
@@ -37,7 +37,7 @@ static int transport_send(void *arg, char *fcall_str,
     int fd, ret;
     char buf[BUFLEN];
     packet *pac, *pac_ret;
-   
+
     pac = (packet *)buf;
 
     /* construct the packet */
@@ -51,8 +51,7 @@ static int transport_send(void *arg, char *fcall_str,
     }
 
     trans->rpc_priv = rpc_priv;
-    g_free (fcall_str);
-    
+
     return 0;
 }
 

--- a/lib/searpc-client.c
+++ b/lib/searpc-client.c
@@ -392,7 +392,7 @@ searpc_client_generic_callback (char *retstr, size_t len,
             json_decref ((json_t *)result);
         }
     }
-    // g_free (data);
+    g_free (data);
 
     return 0;
 }
@@ -414,7 +414,7 @@ searpc_client_async_call_v (SearpcClient *client,
     fstr = fcall_to_str (fname, n_params, args, &len);
     if (!fstr)
         return -1;
-    
+
     int ret;
     AsyncCallData *data = g_new0(AsyncCallData, 1);
     data->client = client;
@@ -425,10 +425,12 @@ searpc_client_async_call_v (SearpcClient *client,
 
     ret = client->async_send (client->async_arg, fstr, len, data);
 
-    g_free(data);
     g_free(fstr);
-
-    return ret;
+    if (ret < 0) {
+        g_free (data);
+        return -1;
+    }
+    return 0;
 }
 
 int


### PR DESCRIPTION
Currently the async client is broken by commit 55001da2
Every line of that commit is wrong: it frees the async data that
is saved by async_send() callback for later use in async recv. Also it frees `fstr`
which is also freed in transport_send() of demo-async-client.c.

This patch undoes most of commit 55001da2
It is also an option to do the plain revert, but, considering that it is already 10 years old,
I decided that freeing of `fstr` in searpc_client_async_call_v() can be left as is now, and instead,
this patch removes it from transport_send() of demo-async-client.c.

With this patch, the async APIs can be used again.